### PR TITLE
feat: only dump default billing orgs

### DIFF
--- a/lib/seed_dump/environment.rb
+++ b/lib/seed_dump/environment.rb
@@ -13,6 +13,8 @@ class SeedDump
 
         if model == Company
           model = model.where('id < 3')
+        elsif model == BillingOrganization
+          model = model.where('id < 3')
         elsif model.column_names.include?('company_id')
           model = model.where('company_id IS NULL OR company_id < 3')
         end


### PR DESCRIPTION
This PR makes sure the DB reseed only imports default Billing Orgs (1: Prospect & 2: Bin).

Also, this repository is a fork of the `seed_dump` gem that adds the `db:seed:dump` rake we use to init our local env 😇 